### PR TITLE
Feature #000001: Add external dependencies OpenCV ImGui GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,5 @@ add_executable(Campo
   main.cpp
 )
 
+add_subdirectory(external)
+

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,28 @@
+include(FetchContent)
+
+FetchContent_Declare(OpenCV
+  GIT_REPOSITORY  https://github.com/opencv/opencv.git
+  GIT_TAG         5.x
+  GIT_PROGRESS    TRUE
+  GIT_SHALLOW     FALSE
+  SYSTEM
+)
+
+FetchContent_Declare(GTest
+  GIT_REPOSITORY  https://github.com/google/googletest.git
+  GIT_TAG         v1.16.0
+  SYSTEM
+)
+
+FetchContent_Declare(ImGui
+  GIT_REPOSITORY  https://github.com/ocornut/imgui.git
+  GIT_TAG         v1.91.8
+  SYSTEM
+)
+
+FetchContent_MakeAvailable(
+  ImGui
+  GTest
+  OpenCV
+)
+


### PR DESCRIPTION
While working on MacOS, OpenCV has been failing build after fetching due to missing includes. 
Recently fix for that was implemented on behalf of OpenCV 5.x branch. [OpenCV changes ](https://github.com/opencv/opencv_contrib/pull/3881)
In order to make OpenCV available, 5.x branch has been used as GIT_TAG. 

GTest version has been set to latest available at 3.Mar.2025
ImGui version has been set to latest available at 3.Mar.2025