### PR TITLE
Feature #000004: Init window with Camera preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set(OpenCVModules
     3d
 )
 
+find_package(OpenGL)
+
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${OpenCV_SOURCE_DIR}/include
     ${OpenCV_BINARY_DIR}
@@ -39,9 +41,27 @@ foreach(module ${OpenCVModules})
     target_include_directories(${PROJECT_NAME} PRIVATE
         ${OPENCV_MODULE_opencv_${module}_LOCATION}/include
     )
-endforeach()
-
-foreach(module ${OpenCVModules})
     target_link_libraries(${PROJECT_NAME} PRIVATE opencv_${module})
 endforeach()
+
+add_library(ImGui STATIC)
+
+set(ImGui_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/imgui-src")
+target_include_directories(ImGui PUBLIC
+    ${ImGui_SOURCE_DIR}
+    ${ImGui_SOURCE_DIR}/backends
+    ${GLFW_SOURCE_DIR}/include
+)
+
+target_sources(ImGui PRIVATE
+    ${ImGui_SOURCE_DIR}/imgui.cpp
+    ${ImGui_SOURCE_DIR}/imgui_demo.cpp
+    ${ImGui_SOURCE_DIR}/imgui_draw.cpp
+    ${ImGui_SOURCE_DIR}/imgui_tables.cpp
+    ${ImGui_SOURCE_DIR}/imgui_widgets.cpp
+    ${ImGui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
+    ${ImGui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glfw ImGui OpenGL::GL)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -20,9 +20,16 @@ FetchContent_Declare(ImGui
   SYSTEM
 )
 
+FetchContent_Declare(GLFW
+  GIT_REPOSITORY  https://github.com/glfw/glfw.git
+  GIT_TAG         3.3.8
+  SYSTEM
+)
+
 FetchContent_MakeAvailable(
   ImGui
   GTest
   OpenCV
+  GLFW
 )
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,87 @@
 #include <iostream>
+#include "imgui.h"
+#include "imgui_impl_glfw.h"
+#include "imgui_impl_metal.h"
 #include "opencv2/opencv.hpp"
+#include <GLFW/glfw3.h>
+#include "backends/imgui_impl_glfw.h"
+#include "backends/imgui_impl_opengl3.h"
 
-using std::cout;
+using std::cerr;
+
+GLuint cvmatToTexture(cv::Mat& mat)
+{
+  GLuint textureId;
+  glGenTextures(1, &textureId);
+  glBindTexture(GL_TEXTURE_2D, textureId);
+
+  cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
+
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, mat.cols, mat.rows, 0, GL_RGB, GL_UNSIGNED_BYTE, mat.data);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+  return textureId;
+}
 
 int main() 
 {
-  cout << "Hello Dear World! I am Campo!\n";  
+  if(!glfwInit()) 
+  {
+    return -1;
+  }
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+ 
+  GLFWwindow* window = glfwCreateWindow(800,600, "Campo", NULL, NULL);
+  glfwMakeContextCurrent(window);
+
+  ImGui::CreateContext();
+  ImGui_ImplGlfw_InitForOpenGL(window, true);
+  ImGui_ImplOpenGL3_Init("#version 410");
+
+  cv::VideoCapture cam(0);
+  if(!cam.isOpened()) {
+    cerr << "Cannot open Your camera\n";
+    return -1;
+  }
+  
+  cv::Mat frame{};
+  GLuint textureId = 0;
+
+  while(!glfwWindowShouldClose(window)) {
+    glfwPollEvents();
+
+    cam >> frame; 
+
+    if(frame.empty()) 
+    {
+      break;
+    }
+    textureId = cvmatToTexture(frame);
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+    ImGui::NewFrame();
+
+    ImGui::Begin("Camera Preview");
+    if(textureId) {
+      ImGui::Image((ImTextureID)(uintptr_t)textureId, ImVec2(frame.cols, frame.rows));
+    }
+    ImGui::End();
+
+    ImGui::Render();
+    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+    glfwSwapBuffers(window);
+  }
+
+  ImGui_ImplGlfw_Shutdown();
+  ImGui::DestroyContext();
+  glfwDestroyWindow(window);
+  glfwTerminate();
   return 0;
 }


### PR DESCRIPTION
System library OpenGL had to be used (currently considering using docker image or swap to Metal)
Extend dependencies with ImGui.
Initialize Main window with Camera Preview 
![image](https://github.com/user-attachments/assets/75bf5f24-b139-4e9f-aaa3-c0b0b3c4d092)
Based on example code from [ImGui](https://github.com/ocornut/imgui/blob/master/examples/example_apple_opengl2/main.mm)